### PR TITLE
Fixed input validation

### DIFF
--- a/realcentroiddialog.py
+++ b/realcentroiddialog.py
@@ -81,12 +81,12 @@ class RealCentroidDialog(QtGui.QDialog):
     def ok(self):
         if len(self.ui.layerBox.currentText()) == 0:
             QtGui.QMessageBox.information(self, "Realcentroid", \
-                QApplication.translate("RealCentroid", \
-                "No polygon layer selected", None, QApplication.UnicodeUTF8))
+                QtGui.QApplication.translate("RealCentroid", \
+                "No polygon layer selected", None, QtGui.QApplication.UnicodeUTF8))
             return
         if len(self.ui.pointEdit.text()) == 0:
             QtGui.QMessageBox.information(self, "Realcentroid", \
-                QApplication.translate("RealCentroid", \
-                "No point layer given", None, QApplication.UnicodeUTF8))
+                QtGui.QApplication.translate("RealCentroid", \
+                "No point layer given", None, QtGui.QApplication.UnicodeUTF8))
             return
         self.accept()


### PR DESCRIPTION
The plugin threw an error when leaving the drop-down menu or the output file name empty because `QApplication` couldn't be found. It needs to be referenced as `QtGui.QApplication` because it's imported using 
``` python
from PyQt4 import QtCore, QtGui
```
and not
```python
from PyQt4.QtGui import QAction, QIcon, QApplication, QMessageBox
```
like in `realcentroid.py`.